### PR TITLE
Re-register recipes when recipes are reloaded.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ hs_err_pid*
 target/
 
 \.idea/
+.*

--- a/pom.xml
+++ b/pom.xml
@@ -6,23 +6,23 @@
 
     <groupId>com.karlofduty</groupId>
     <artifactId>EMCRecipies</artifactId>
-    <version>1.4.0</version>
+    <version>1.5.0</version>
 
     <properties>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
     </properties>
     <repositories>
         <repository>
-            <id>spigot-repo</id>
-            <url>https://hub.spigotmc.org/nexus/content/groups/public/</url>
+            <id>papermc</id>
+            <url>https://papermc.io/repo/repository/maven-public/</url>
         </repository>
     </repositories>
     <dependencies>
         <dependency>
-            <groupId>org.spigotmc</groupId>
-            <artifactId>spigot-api</artifactId>
-            <version>1.16.5-R0.1-SNAPSHOT</version>
+            <groupId>io.papermc.paper</groupId>
+            <artifactId>paper-api</artifactId>
+            <version>1.17.1-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/com/karlofduty/EMCRecipies/EMCRecipies.java
+++ b/src/main/java/com/karlofduty/EMCRecipies/EMCRecipies.java
@@ -1,17 +1,33 @@
 package com.karlofduty.EMCRecipies;
 
+import io.papermc.paper.event.server.ServerResourcesReloadedEvent;
+import org.bukkit.Bukkit;
+import org.bukkit.Material;
+import org.bukkit.NamespacedKey;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
 import org.bukkit.inventory.FurnaceRecipe;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.ShapedRecipe;
 import org.bukkit.inventory.ShapelessRecipe;
-import org.bukkit.plugin.java.*;
-import org.bukkit.plugin.*;
-import org.bukkit.*;
+import org.bukkit.plugin.java.JavaPlugin;
 
-public class EMCRecipies extends JavaPlugin
+public class EMCRecipies extends JavaPlugin implements Listener
 {
     public void onEnable()
     {
+        Bukkit.getPluginManager().registerEvents(this, this);
+        registerRecipes();
+    }
+
+    // Called when datapacks/recipes are reloaded, recipes will have to be registered again.
+    @EventHandler
+    public void onResourcesReload(ServerResourcesReloadedEvent event)
+    {
+        registerRecipes();
+    }
+
+    public void registerRecipes() {
         // POWERED RAIL
         final ShapedRecipe rail = new ShapedRecipe(new NamespacedKey(this, "emc_powered_rail"), new ItemStack(Material.POWERED_RAIL, 16));
         rail.shape("I I", "ISI", "IRI");


### PR DESCRIPTION
Adds support for the /minecraft:reload command by re-registering recipes when it is used, since the server removes all added recipes. 